### PR TITLE
add yaml file for goodtables validation

### DIFF
--- a/goodtables.yml
+++ b/goodtables.yml
@@ -1,0 +1,5 @@
+# tell goodtables.io to specifically ignore public-body-schema.json,
+# because it is not a full data package, just the schema part
+datapackages:
+  - 'datapackage.json'
+


### PR DESCRIPTION
I've added a `goodtables.yml` file in order to tell Goodtables.io to look only into `datapackage.json` and ignore `public-body-schema.json` (which is just the table schema part).