### PR TITLE
replace mailing list subscribe form with forum link

### DIFF
--- a/views/index.jade
+++ b/views/index.jade
@@ -30,14 +30,10 @@ block content
         a(href='http://opendatacommons.org/licenses/pddl/1.0/') Public Domain Dedication and License
         |. Please use and reuse freely.
       h3 Contribute
-      | Want to contribute (or just have a question)? Join the Open Knowledge Labs mailing list:
       p
-        form.form-inline(action='http://lists.okfn.org/mailman/subscribe/okfn-labs')
-          .input-append
-            input.input-medium(type='email', name='email', placeholder='your@email.com')
-            button.btn.btn-info(type='submit') 
-              i.icon-envelope
-              |  Sign up
+        | Want to contribute (or just have a question)? Join the Open Knowledge Discuss forum and see the
+        a(href='https://discuss.okfn.org/c/open-knowledge-labs/34') Open Knowledge Labs
+        | section.
       p
         | Want to dive straight in? All the code 
         em and


### PR DESCRIPTION
The old mailing list does not even exist any more. As @loleg suggested on #107, let's replace the mailing list subscription form with just a link to the forum's Open Knowledge Labs section.