### PR TITLE
fixes #117: run workflow only on main repo

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   update:
+    if: github.repository == 'okfn/publicbodies'
     runs-on: ubuntu-latest
     name: Update BR data source
     steps:


### PR DESCRIPTION
I just noticed that the Github Actions update bot was running on every fork of this repository (issue #117). By default, it should only run on the main repo, so as not to overwhelm the data source servers and potentially get us blocked from updates.