### PR TITLE
Adds https redirection in production mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
 # DESCRIPTION: publicbodies.org website
 # BUILD: docker build --rm -t publicbodies .
 # 
-# If you want to just build the documentation portal locally, do:
-#   docker build --rm -t publicbodies .
+# If you want to build the portal locally in development mode, do:
+#   docker build --rm -t publicbodies . --build-arg NODE_ENV=development
 # to build the container, then run
 #   docker run --rm --name publicbodies -p 3000:3000 -it publicbodies node index.js
 # open http://localhost:3000 on your browser to see the portal.
 
 FROM node:12
 
+ARG NODE_ENV=production
+
 # Never prompt the user for choices on installation/configuration of packages
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
-ENV NODE_ENV=production
+ENV NODE_ENV=$NODE_ENV
 # from https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#global-npm-dependencies
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH=$PATH:/home/node/.npm-global/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # If you want to just build the documentation portal locally, do:
 #   docker build --rm -t publicbodies .
 # to build the container, then run
-#   docker run --rm --volume="$PWD:/home/node/portal" -p 3000:3000 -it publicbodies node index.js
+#   docker run --rm --name publicbodies -p 3000:3000 -it publicbodies node index.js
 # open http://localhost:3000 on your browser to see the portal.
 
 FROM node:12
@@ -25,6 +25,14 @@ RUN mkdir -p /home/node/portal
 COPY ./package.json /home/node/portal/package.json
 WORKDIR /home/node/portal
 RUN npm install .
+
+# copy website resources
+COPY ./lib /home/node/portal/lib
+COPY ./routes /home/node/portal/routes
+COPY ./views /home/node/portal/views
+COPY ./public /home/node/portal/public
+COPY ./data /home/node/portal/data
+COPY ./index.js /home/node/portal/
 
 # port Docusaurus runs on
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The website is a node webapp. To get it running:
   If you're using Docker, start the container instead:
 
         ```
-        docker run --rm --volume="$PWD:/home/node/portal" -p 3000:3000 -it publicbodies node index.js
+        docker run --rm --name publicbodies -p 3000:3000 -it publicbodies node index.js
         ```
 
 The list of outstanding issues is at: <https://github.com/okfn/publicbodies/issues>

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ The website is a node webapp. To get it running:
         ```
         docker build --rm -t publicbodies .
         ```
+  
+  If you are building a development environment, please use:
+
+        ```
+        docker build --rm -t publicbodies . --build-arg NODE_ENV=development
+        ```
+  so that you can get debugging information.
 
 4. Run the webapp:
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  */
 
 var express = require('express'),
+    errorhandler = require('errorhandler'),
     favicon = require('serve-favicon'),
     morgan = require('morgan'),
     lessMiddleware = require('less-middleware'),
@@ -22,8 +23,9 @@ app.use(lessMiddleware(__dirname + '/public'));
 app.use(express.static(path.join(__dirname, 'public')));
 
 // development only
-if ('development' === app.get('env')) {
-    app.use(express.errorHandler());
+if ('development' === process.env.NODE_ENV) {
+    app.use(errorhandler());
+}
 }
 
 app.get('/', routes.index);

--- a/index.js
+++ b/index.js
@@ -26,6 +26,16 @@ app.use(express.static(path.join(__dirname, 'public')));
 if ('development' === process.env.NODE_ENV) {
     app.use(errorhandler());
 }
+else { // production only
+    // handle https redirect
+    function ensureSecure(req, res, next){
+        if(req.secure){
+        // OK, continue
+        return next();
+        };
+        res.redirect('https://' + req.hostname + req.url);
+    }
+    app.all('*', ensureSecure);
 }
 
 app.get('/', routes.index);

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "async": "~0.2.9",
     "csv": "~5.0.0",
     "dirty": "~0.9.7",
+    "errorhandler": "~1.5.1",
     "express": "^4.7.4",
     "less-middleware": "~3.1.0",
     "morgan": "~1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publicbodies",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A database of public bodies such as government departments, ministries etc.",
   "main": "site/make.js",
   "directories": {


### PR DESCRIPTION
This PR will:

* fix development mode, which was not working before, and add instructions on how to build the Docker container for both development and production mode (the latter is the default);
* fix error handling in development mode, to bring it up to modern usage with Express 4;
* bake the portal files into the docker image, instead of mounting a volume (mounting a volume with the `node_modules` folder was causing a problem);
* add http -> https redirection in production mode (fixes #107).