### PR TITLE
Fix #135 move from GoodTables to F11d Repository

### DIFF
--- a/.github/workflows/frictionless.yaml
+++ b/.github/workflows/frictionless.yaml
@@ -1,0 +1,18 @@
+name: publicbodies
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Validate data
+        uses: frictionlessdata/repository@v1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![goodtables.io](https://goodtables.io/badge/github/okfn/publicbodies.svg)](https://goodtables.io/github/okfn/publicbodies)
+[![Data](https://github.com/okfn/publicbodies/actions/workflows/frictionless.yaml/badge.svg)](https://repository.frictionlessdata.io/report?user=okfn&repo=publicbodies&flow=publicbodies)
 
 A database of public bodies (or organizations):
 


### PR DESCRIPTION
GoodTables as a data validation service is soon going to be discontinued. This PR moves data validation to its successor, Frictionless Repository (#135).