### PR TITLE
Run data capture in sequential steps

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -5,10 +5,10 @@ on:
     - cron: 45 3 * * 0
 
 jobs:
-  update-br:
+  update-data:
     if: github.repository == 'okfn/publicbodies'
     runs-on: ubuntu-latest
-    name: Update BR data source
+    name: Update data sources
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -22,30 +22,15 @@ jobs:
           path: "scripts/requirements.txt"
       - name: Update br.csv file
         run: "python3 scripts/import/br/import_br.py --output data/br.csv"
-      - name: push
+      - name: push BR data
         uses: actions-x/commit@v2
         with:
           email: 41898282+github-actions[bot]@users.noreply.github.com
           name: GitHub Actions Update Bot
           message: "update BR data source automatically scheduled with Github actions"
-  update-it:
-    if: github.repository == 'okfn/publicbodies'
-    runs-on: ubuntu-latest
-    name: Update IT data source
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-          architecture: x64
-      - name: Install Python dependencies
-        uses: py-actions/py-dependency-install@v2
-        with:
-          path: "scripts/requirements.txt"
-      - name: Update br.csv file
+      - name: Update it.csv file
         run: "python3 scripts/import/it/import_it.py --output data/it.csv"
-      - name: push
+      - name: push IT data
         uses: actions-x/commit@v2
         with:
           email: 41898282+github-actions[bot]@users.noreply.github.com


### PR DESCRIPTION
Solves #149 by configuring the bot to update the data one file at a time. This is done in order to avoid merge conflicts in the repository when the bot runs them in parallel.