### PR TITLE
Commit to the main branch (default is master)

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -35,6 +35,7 @@ jobs:
       - name: commit & push with rebase
         uses: benkaiser/rebase-commit-push@v1.1
         with:
+          branch: main
           author_email: 41898282+github-actions[bot]@users.noreply.github.com
           author_name: GitHub Actions Update Bot
           message: "Update ${{ matrix.source }} data source automatically scheduled with Github actions"


### PR DESCRIPTION
According to the [documentation](https://github.com/benkaiser/rebase-commit-push#inputs) of the Github Actions script, the default branch is `master`. So we have to manually specify we want to commit to the `main` branch.

- Fixes #163